### PR TITLE
Add recipe, menu, summary, and exception dashboards

### DIFF
--- a/common/costing.py
+++ b/common/costing.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 from typing import Optional
 
+import pandas as pd
+
 CONVERSIONS_TO_OZ = {
     "oz": 1.0,
     "lb": 16.0,
@@ -33,3 +35,229 @@ def line_cost(qty: float, uom: str, cost_per_oz: float | None, cost_per_each: fl
     if cost_per_each is not None and uom.lower() in ("each", "ea"):
         return qty * cost_per_each
     return None
+
+
+def prepare_ingredient_costs(ingredients: pd.DataFrame) -> pd.DataFrame:
+    """Return ingredient data with normalized cost columns for recipe costing."""
+
+    if ingredients is None or ingredients.empty:
+        return pd.DataFrame(
+            columns=[
+                "ingredient_key",
+                "description",
+                "vendor",
+                "item_number",
+                "cost_per_oz",
+                "cost_per_each",
+                "default_uom",
+            ]
+        )
+
+    df = ingredients.copy()
+    if "description" not in df.columns:
+        df["description"] = df.get("name", "")
+
+    df["ingredient_key"] = df["description"].fillna("").astype(str).str.strip()
+    df["vendor"] = df.get("vendor", "").fillna("")
+    df["item_number"] = df.get("item_number", "").fillna("")
+
+    numeric_cols = ["case_pack", "case_cost", "cost_per_count"]
+    for col in numeric_cols:
+        if col in df.columns:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
+        else:
+            df[col] = 0.0
+
+    df["case_uom"] = df.get("case_uom", "").fillna("")
+    df["count_uom"] = df.get("count_uom", "").fillna("")
+
+    cost_per_each = df.get("cost_per_count", pd.Series(dtype=float)).copy()
+
+    mask_each = df["count_uom"].str.lower().isin({"each", "ea", "ct"})
+    calc_each = pd.Series(index=df.index, dtype=float)
+    calc_each.loc[mask_each] = (
+        df.loc[mask_each, "case_cost"]
+        / df.loc[mask_each, "case_pack"].replace({0: pd.NA})
+    )
+    cost_per_each = cost_per_each.fillna(calc_each)
+
+    df["cost_per_each"] = cost_per_each
+
+    total_oz = df.apply(
+        lambda row: to_oz(row["case_pack"], row.get("case_uom")), axis=1
+    )
+    df["cost_per_oz"] = [
+        (row_cost / total) if total not in (None, 0) else None
+        for row_cost, total in zip(df["case_cost"], total_oz)
+    ]
+
+    default_uom = []
+    for _, row in df.iterrows():
+        for candidate in (row.get("count_uom"), row.get("case_uom"), "each"):
+            if candidate:
+                default_uom.append(str(candidate))
+                break
+        else:
+            default_uom.append("each")
+    df["default_uom"] = default_uom
+
+    return df[
+        [
+            "ingredient_key",
+            "description",
+            "vendor",
+            "item_number",
+            "cost_per_oz",
+            "cost_per_each",
+            "default_uom",
+        ]
+    ]
+
+
+def compute_recipe_costs(
+    recipes: pd.DataFrame,
+    recipe_lines: pd.DataFrame,
+    ingredients: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    """Compute costed recipe lines and per-recipe profitability summaries."""
+
+    ingredient_costs = prepare_ingredient_costs(ingredients)
+
+    if recipe_lines is None or recipe_lines.empty:
+        empty_lines = pd.DataFrame(
+            columns=[
+                "recipe_id",
+                "line_id",
+                "ingredient",
+                "qty",
+                "uom",
+                "prep_note",
+                "line_cost",
+            ]
+        )
+        summary = pd.DataFrame(
+            columns=[
+                "recipe_id",
+                "name",
+                "menu_price",
+                "recipe_cost",
+                "margin",
+                "margin_pct",
+                "cost_per_serving",
+                "yield_qty",
+                "yield_uom",
+            ]
+        )
+        return empty_lines, summary
+
+    lines = recipe_lines.copy()
+    for col in ("recipe_id", "ingredient"):
+        if col not in lines.columns:
+            lines[col] = ""
+
+    if "line_id" not in lines.columns:
+        lines["line_id"] = lines.groupby("recipe_id").cumcount() + 1
+
+    numeric_cols = ["qty", "line_cost"]
+    for col in numeric_cols:
+        if col in lines.columns:
+            lines[col] = pd.to_numeric(lines[col], errors="coerce")
+        else:
+            lines[col] = 0.0
+
+    lines["uom"] = lines.get("uom", "").fillna("")
+    lines["prep_note"] = lines.get("prep_note", "").fillna("")
+
+    ingredient_lookup = (
+        ingredient_costs.set_index("ingredient_key")
+        if not ingredient_costs.empty
+        else pd.DataFrame()
+    )
+
+    def compute_cost(row):
+        key = str(row.get("ingredient", "")).strip()
+        cost_per_oz = None
+        cost_per_each = None
+        default_uom = row.get("uom")
+        if not ingredient_lookup.empty and key in ingredient_lookup.index:
+            info = ingredient_lookup.loc[key]
+            cost_per_oz = info.get("cost_per_oz")
+            cost_per_each = info.get("cost_per_each")
+            default_uom = row.get("uom") or info.get("default_uom")
+        qty = row.get("qty")
+        if pd.isna(qty):
+            return None
+        uom = default_uom or row.get("uom")
+        if not uom:
+            return None
+        return line_cost(float(qty), str(uom), cost_per_oz, cost_per_each)
+
+    lines["computed_cost"] = lines.apply(compute_cost, axis=1)
+    existing_cost = lines.get("line_cost")
+    if existing_cost is None:
+        existing_cost = pd.Series(index=lines.index, dtype=float)
+    else:
+        existing_cost = pd.to_numeric(existing_cost, errors="coerce")
+    lines["line_cost"] = lines["computed_cost"].fillna(existing_cost)
+    lines["line_cost"] = lines["line_cost"].fillna(0.0).astype(float)
+
+    if not ingredient_lookup.empty:
+        lines["ingredient_key"] = lines["ingredient"].astype(str).str.strip()
+        lines = lines.merge(
+            ingredient_costs,
+            on="ingredient_key",
+            how="left",
+            suffixes=("", "_ing"),
+        )
+        lines = lines.drop(columns=["key_0"], errors="ignore")
+
+    recipe_cols = [
+        "recipe_id",
+        "name",
+        "menu_price",
+        "yield_qty",
+        "yield_uom",
+    ]
+    recipes_slim = pd.DataFrame(columns=recipe_cols)
+    if recipes is not None and not recipes.empty:
+        recipes_slim = recipes.copy()
+        for col in recipe_cols:
+            if col not in recipes_slim.columns:
+                recipes_slim[col] = 0 if "qty" in col else ""
+        recipes_slim["menu_price"] = pd.to_numeric(
+            recipes_slim["menu_price"], errors="coerce"
+        )
+        recipes_slim["yield_qty"] = pd.to_numeric(
+            recipes_slim["yield_qty"], errors="coerce"
+        )
+
+    summary = (
+        lines.groupby("recipe_id", dropna=False)["line_cost"].sum().reset_index()
+    )
+    summary = summary.merge(recipes_slim, on="recipe_id", how="left")
+    summary = summary.rename(columns={"line_cost": "recipe_cost"})
+
+    summary["menu_price"] = summary["menu_price"].fillna(0.0)
+    summary["recipe_cost"] = summary["recipe_cost"].fillna(0.0)
+    summary["yield_qty"] = summary["yield_qty"].fillna(0.0)
+
+    summary["margin"] = summary["menu_price"] - summary["recipe_cost"]
+    summary["margin_pct"] = summary.apply(
+        lambda row: (row["margin"] / row["menu_price"])
+        if row["menu_price"] not in (0, None)
+        else None,
+        axis=1,
+    )
+    summary["cost_per_serving"] = summary.apply(
+        lambda row: (row["recipe_cost"] / row["yield_qty"])
+        if row["yield_qty"] not in (0, None)
+        else None,
+        axis=1,
+    )
+
+    summary["margin_pct"] = pd.to_numeric(summary["margin_pct"], errors="coerce")
+    summary["cost_per_serving"] = pd.to_numeric(
+        summary["cost_per_serving"], errors="coerce"
+    )
+
+    return lines, summary

--- a/pages/3_👨‍🍳_Recipes.py
+++ b/pages/3_👨‍🍳_Recipes.py
@@ -1,13 +1,386 @@
-"""Placeholder for future recipe costing workspace."""
+"""Interactive recipe builder backed by the CSV data layer."""
 
 from __future__ import annotations
 
+from uuid import uuid4
+
+import pandas as pd
 import streamlit as st
+
+from common.costing import compute_recipe_costs, prepare_ingredient_costs
+from common.db import read_table, toast_err, toast_info, toast_ok, write_table
 
 st.set_page_config(page_title="Recipes", layout="wide")
 
 st.title("👨‍🍳 Recipes")
-st.info(
-    "Recipe costing will return in a future release once the file-based data layer ships full menu support. "
-    "For now, use the Ingredient Master and Export views to access raw data."
-)
+st.caption("Cost dishes, track profitability, and keep prep notes in one place.")
+
+
+@st.cache_data(show_spinner=False)
+def load_data() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    recipes_df = read_table("recipes")
+    lines_df = read_table("recipe_lines")
+    ingredients_df = read_table("ingredient_master")
+    return recipes_df, lines_df, ingredients_df
+
+
+recipes, recipe_lines, ingredients = load_data()
+
+recipe_defaults = {
+    "recipe_id": "",
+    "name": "",
+    "category": "",
+    "yield_qty": 1.0,
+    "yield_uom": "each",
+    "menu_price": 0.0,
+    "notes": "",
+}
+
+if recipes.empty:
+    recipes = pd.DataFrame(columns=list(recipe_defaults.keys()))
+
+for column, default in recipe_defaults.items():
+    if column not in recipes.columns:
+        recipes[column] = default
+
+if "recipe_id" not in recipes.columns:
+    recipes["recipe_id"] = ""
+
+missing_ids = recipes["recipe_id"].isin(["", None, pd.NA])
+if missing_ids.any():
+    recipes.loc[missing_ids, "recipe_id"] = [str(uuid4()) for _ in range(missing_ids.sum())]
+    write_table("recipes", recipes)
+
+numeric_recipe_cols = ["yield_qty", "menu_price"]
+for col in numeric_recipe_cols:
+    recipes[col] = pd.to_numeric(recipes[col], errors="coerce").fillna(
+        recipe_defaults.get(col, 0.0)
+    )
+
+line_columns = ["recipe_id", "line_id", "ingredient", "qty", "uom", "prep_note", "line_cost"]
+if recipe_lines.empty:
+    recipe_lines = pd.DataFrame(columns=line_columns)
+
+for col in line_columns:
+    if col not in recipe_lines.columns:
+        recipe_lines[col] = 0 if col in {"qty", "line_cost"} else ""
+
+recipe_lines["qty"] = pd.to_numeric(recipe_lines["qty"], errors="coerce").fillna(0.0)
+recipe_lines["line_cost"] = pd.to_numeric(
+    recipe_lines["line_cost"], errors="coerce"
+).fillna(0.0)
+
+ingredient_costs = prepare_ingredient_costs(ingredients)
+costed_lines, recipe_summary = compute_recipe_costs(recipes, recipe_lines, ingredients)
+
+ingredient_options = ingredient_costs["ingredient_key"].dropna().tolist()
+ingredient_options = sorted(dict.fromkeys(ingredient_options))
+
+if not ingredient_options:
+    toast_info("Populate the Ingredient Master to unlock the recipe builder.")
+
+if "selected_recipe_id" not in st.session_state:
+    st.session_state.selected_recipe_id = (
+        recipes["recipe_id"].iloc[0] if not recipes.empty else None
+    )
+
+
+def create_recipe(name: str, category: str, yield_qty: float, yield_uom: str, price: float) -> None:
+    new_id = str(uuid4())
+    row = {
+        "recipe_id": new_id,
+        "name": name.strip(),
+        "category": category.strip(),
+        "yield_qty": yield_qty,
+        "yield_uom": yield_uom.strip() or "each",
+        "menu_price": price,
+        "notes": "",
+    }
+    updated = pd.concat([recipes, pd.DataFrame([row])], ignore_index=True)
+    write_table("recipes", updated)
+    toast_ok(f"Created recipe '{row['name']}'")
+    st.session_state.selected_recipe_id = new_id
+    st.cache_data.clear()
+    st.rerun()
+
+
+library_col, builder_col = st.columns([1, 2])
+
+with library_col:
+    st.subheader("Recipe library")
+    if recipe_summary.empty:
+        st.info("Add your first recipe to begin costing.")
+    else:
+        display_cols = recipe_summary.copy()
+        display_cols["margin_pct"] = display_cols["margin_pct"].fillna(0) * 100
+        display_cols["cost_per_serving"] = display_cols["cost_per_serving"].fillna(0)
+        st.dataframe(
+            display_cols[["name", "menu_price", "recipe_cost", "margin", "margin_pct"]]
+            .rename(
+                columns={
+                    "name": "Recipe",
+                    "menu_price": "Menu $",
+                    "recipe_cost": "Cost $",
+                    "margin": "Margin $",
+                    "margin_pct": "Margin %",
+                }
+            )
+            .style.format({"Menu $": "$%.2f", "Cost $": "$%.2f", "Margin $": "$%.2f", "Margin %": "%.1f%%"}),
+            use_container_width=True,
+            hide_index=True,
+        )
+
+    with st.expander("➕ Add recipe"):
+        with st.form("new_recipe_form", clear_on_submit=True):
+            new_name = st.text_input("Name", placeholder="Fried Chicken Sandwich")
+            new_category = st.text_input("Category", placeholder="Sandwiches")
+            new_yield = st.number_input("Yield qty", min_value=0.0, value=1.0)
+            new_uom = st.text_input("Yield unit", value="each")
+            new_price = st.number_input("Menu price", min_value=0.0, value=0.0, step=0.5)
+            create_clicked = st.form_submit_button("Create recipe", type="primary")
+
+            if create_clicked:
+                if not new_name.strip():
+                    toast_err("Recipe name is required")
+                else:
+                    create_recipe(new_name, new_category, new_yield, new_uom, new_price)
+
+    recipe_choices = {
+        r.get("name", f"Recipe {i+1}") or f"Recipe {i+1}": r["recipe_id"]
+        for i, r in recipes.sort_values("name", na_position="last").iterrows()
+    }
+    if recipe_choices:
+        selected_name = st.selectbox(
+            "Edit recipe",
+            list(recipe_choices.keys()),
+            index=list(recipe_choices.values()).index(st.session_state.selected_recipe_id)
+            if st.session_state.selected_recipe_id in recipe_choices.values()
+            else 0,
+        )
+        st.session_state.selected_recipe_id = recipe_choices[selected_name]
+
+
+if not recipes.empty and st.session_state.selected_recipe_id:
+    recipe_id = st.session_state.selected_recipe_id
+    current_recipe = recipes[recipes["recipe_id"] == recipe_id].iloc[0].to_dict()
+
+    with builder_col:
+        st.subheader(f"Build: {current_recipe.get('name') or 'Untitled'}")
+        header_cols = st.columns(4)
+        name_val = header_cols[0].text_input(
+            "Recipe name", value=current_recipe.get("name", ""), key=f"recipe_name_{recipe_id}"
+        )
+        category_val = header_cols[1].text_input(
+            "Category", value=current_recipe.get("category", ""), key=f"recipe_cat_{recipe_id}"
+        )
+        yield_qty_val = header_cols[2].number_input(
+            "Yield qty",
+            min_value=0.0,
+            value=float(current_recipe.get("yield_qty", 1.0) or 0.0),
+            step=0.25,
+            key=f"recipe_yield_{recipe_id}",
+        )
+        yield_uom_val = header_cols[3].text_input(
+            "Yield unit",
+            value=current_recipe.get("yield_uom", "each"),
+            key=f"recipe_yielduom_{recipe_id}",
+        )
+
+        price_cols = st.columns(2)
+        menu_price_val = price_cols[0].number_input(
+            "Menu price",
+            min_value=0.0,
+            value=float(current_recipe.get("menu_price", 0.0) or 0.0),
+            step=0.5,
+            key=f"recipe_price_{recipe_id}",
+        )
+        notes_val = price_cols[1].text_input(
+            "Notes",
+            value=current_recipe.get("notes", ""),
+            key=f"recipe_notes_{recipe_id}",
+        )
+
+        base_lines = costed_lines[costed_lines["recipe_id"] == recipe_id][
+            ["ingredient", "qty", "uom", "prep_note"]
+        ].copy()
+
+        if base_lines.empty:
+            base_lines = pd.DataFrame(
+                [{"ingredient": "", "qty": 0.0, "uom": "", "prep_note": ""}]
+            )
+
+        base_lines["qty"] = pd.to_numeric(base_lines["qty"], errors="coerce").fillna(0.0)
+        base_lines["uom"] = base_lines["uom"].fillna("")
+        base_lines["prep_note"] = base_lines["prep_note"].fillna("")
+
+        editor_config = {
+            "ingredient": st.column_config.SelectboxColumn(
+                "Ingredient",
+                options=ingredient_options,
+                help="Choose from the Ingredient Master",
+            ),
+            "qty": st.column_config.NumberColumn("Qty", min_value=0.0, step=0.1),
+            "uom": st.column_config.SelectboxColumn(
+                "UOM",
+                options=["oz", "lb", "g", "kg", "ml", "L", "qt", "gal", "each", "ea"],
+            ),
+            "prep_note": st.column_config.TextColumn("Prep notes"),
+        }
+
+        edited_lines_raw = st.data_editor(
+            base_lines,
+            key=f"recipe_editor_{recipe_id}",
+            column_config=editor_config,
+            num_rows="dynamic",
+            hide_index=True,
+            use_container_width=True,
+        )
+
+        edited_lines = pd.DataFrame(edited_lines_raw)
+        if not edited_lines.empty:
+            edited_lines["ingredient"] = (
+                edited_lines.get("ingredient", "").fillna("").astype(str).str.strip()
+            )
+            edited_lines["qty"] = pd.to_numeric(
+                edited_lines.get("qty", 0), errors="coerce"
+            ).fillna(0.0)
+            edited_lines["uom"] = edited_lines.get("uom", "").fillna("")
+            edited_lines["prep_note"] = edited_lines.get("prep_note", "").fillna("")
+            edited_lines = edited_lines[
+                edited_lines["ingredient"].str.len() > 0
+            ]
+        else:
+            edited_lines = pd.DataFrame(columns=["ingredient", "qty", "uom", "prep_note"])
+
+        edited_lines["recipe_id"] = recipe_id
+
+        preview_recipes = recipes.copy()
+        recipe_mask = preview_recipes["recipe_id"] == recipe_id
+        preview_recipes.loc[recipe_mask, "name"] = name_val
+        preview_recipes.loc[recipe_mask, "category"] = category_val
+        preview_recipes.loc[recipe_mask, "yield_qty"] = yield_qty_val
+        preview_recipes.loc[recipe_mask, "yield_uom"] = yield_uom_val
+        preview_recipes.loc[recipe_mask, "menu_price"] = menu_price_val
+        preview_recipes.loc[recipe_mask, "notes"] = notes_val
+
+        other_lines = recipe_lines[recipe_lines["recipe_id"] != recipe_id]
+        combined_lines = pd.concat([other_lines, edited_lines], ignore_index=True)
+
+        preview_lines, preview_summary = compute_recipe_costs(
+            preview_recipes, combined_lines, ingredients
+        )
+
+        selected_preview_lines = preview_lines[preview_lines["recipe_id"] == recipe_id].copy()
+        selected_summary = preview_summary[preview_summary["recipe_id"] == recipe_id]
+
+        if not selected_summary.empty:
+            summary_row = selected_summary.iloc[0]
+            metric_cols = st.columns(4)
+            metric_cols[0].metric(
+                "Recipe cost",
+                f"${summary_row['recipe_cost']:.2f}",
+            )
+            metric_cols[1].metric(
+                "Menu price",
+                f"${summary_row['menu_price']:.2f}",
+            )
+            cost_per = summary_row.get("cost_per_serving")
+            metric_cols[2].metric(
+                "Cost / serving",
+                f"${cost_per:.2f}" if pd.notna(cost_per) else "—",
+            )
+            margin_pct = summary_row.get("margin_pct")
+            metric_cols[3].metric(
+                "Margin %",
+                f"{margin_pct*100:.1f}%" if pd.notna(margin_pct) else "—",
+            )
+
+        if not selected_preview_lines.empty:
+            display_lines = selected_preview_lines[
+                ["ingredient", "qty", "uom", "line_cost", "prep_note"]
+            ].copy()
+            display_lines = display_lines.rename(
+                columns={
+                    "ingredient": "Ingredient",
+                    "qty": "Qty",
+                    "uom": "UOM",
+                    "line_cost": "Cost $",
+                    "prep_note": "Prep notes",
+                }
+            )
+            st.dataframe(
+                display_lines.style.format({"Cost $": "$%.2f"}),
+                use_container_width=True,
+                hide_index=True,
+            )
+        else:
+            st.info("Add ingredients to cost the recipe.")
+
+        save_clicked = st.button("💾 Save recipe", type="primary")
+
+        if save_clicked:
+            if not name_val.strip():
+                toast_err("Recipe needs a name before saving.")
+            else:
+                persist_lines = selected_preview_lines.copy()
+                persist_lines = persist_lines.sort_values("line_id")
+                persist_lines["line_id"] = (
+                    range(1, persist_lines.shape[0] + 1)
+                    if persist_lines.shape[0] > 0
+                    else []
+                )
+                columns_to_keep = [
+                    "recipe_id",
+                    "line_id",
+                    "ingredient",
+                    "qty",
+                    "uom",
+                    "prep_note",
+                    "line_cost",
+                    "vendor",
+                    "item_number",
+                    "cost_per_oz",
+                    "cost_per_each",
+                    "default_uom",
+                ]
+                for col in columns_to_keep:
+                    if col not in persist_lines.columns:
+                        persist_lines[col] = "" if col not in {"qty", "line_cost", "cost_per_oz", "cost_per_each"} else 0.0
+
+                persist_lines["qty"] = pd.to_numeric(persist_lines["qty"], errors="coerce").fillna(0.0)
+                persist_lines["line_cost"] = pd.to_numeric(
+                    persist_lines["line_cost"], errors="coerce"
+                ).fillna(0.0)
+
+                updated_lines = pd.concat(
+                    [
+                        recipe_lines[recipe_lines["recipe_id"] != recipe_id],
+                        persist_lines[columns_to_keep],
+                    ],
+                    ignore_index=True,
+                )
+
+                updated_recipes = recipes.copy()
+                mask = updated_recipes["recipe_id"] == recipe_id
+                updated_recipes.loc[mask, [
+                    "name",
+                    "category",
+                    "yield_qty",
+                    "yield_uom",
+                    "menu_price",
+                    "notes",
+                ]] = [
+                    name_val,
+                    category_val,
+                    yield_qty_val,
+                    yield_uom_val,
+                    menu_price_val,
+                    notes_val,
+                ]
+
+                write_table("recipes", updated_recipes)
+                write_table("recipe_lines", updated_lines)
+                toast_ok("Recipe saved")
+                st.cache_data.clear()
+                st.rerun()
+

--- a/pages/4_🍽️_Menu_Management.py
+++ b/pages/4_🍽️_Menu_Management.py
@@ -1,13 +1,216 @@
-"""Placeholder page for menu management (phase 2)."""
+"""Menu engineering insights blending recipes, inventory, and orders."""
 
 from __future__ import annotations
 
+import pandas as pd
 import streamlit as st
+
+from common.costing import compute_recipe_costs
+from common.db import (
+    latest_inventory,
+    latest_order,
+    read_table,
+    toast_info,
+)
 
 st.set_page_config(page_title="Menu Management", layout="wide")
 
 st.title("🍽️ Menu Management")
-st.info(
-    "Menu engineering analytics will plug into the new CSV-backed store in a future phase. "
-    "Current sprint is focused on inventory, ordering, and catalog ETL."
+st.caption(
+    "Understand profitability, watch par gaps, and spot engineering opportunities at a glance."
 )
+
+
+def normalize_inventory(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return pd.DataFrame()
+    inventory = df.copy()
+    columns_lower = {c.lower(): c for c in inventory.columns}
+
+    name_col = columns_lower.get("description")
+    if name_col is None:
+        for candidate in ["item", "ingredient", "name"]:
+            if candidate in columns_lower:
+                name_col = columns_lower[candidate]
+                break
+    qty_col = None
+    for candidate in ["on_hand", "on_hand_qty", "qty", "quantity", "count"]:
+        if candidate in columns_lower:
+            qty_col = columns_lower[candidate]
+            break
+
+    rename_map = {}
+    if name_col:
+        rename_map[name_col] = "description"
+    if qty_col:
+        rename_map[qty_col] = "inventory_qty"
+
+    inventory = inventory.rename(columns=rename_map)
+    if "description" not in inventory.columns:
+        inventory["description"] = inventory.index.astype(str)
+    if "inventory_qty" not in inventory.columns:
+        inventory["inventory_qty"] = 0
+
+    inventory["description"] = inventory["description"].astype(str).str.strip()
+    inventory["inventory_qty"] = pd.to_numeric(
+        inventory["inventory_qty"], errors="coerce"
+    ).fillna(0.0)
+    return inventory[["description", "inventory_qty"]]
+
+
+recipes = read_table("recipes")
+recipe_lines = read_table("recipe_lines")
+ingredients = read_table("ingredient_master")
+
+costed_lines, recipe_summary = compute_recipe_costs(recipes, recipe_lines, ingredients)
+
+if recipe_summary.empty:
+    toast_info("Add recipes to unlock menu engineering insights.")
+    st.stop()
+
+recipe_summary = recipe_summary.fillna(0)
+recipe_summary["margin_pct"] = recipe_summary["margin_pct"] * 100
+recipe_summary["cost_pct"] = recipe_summary.apply(
+    lambda row: (row["recipe_cost"] / row["menu_price"] * 100)
+    if row["menu_price"] > 0
+    else None,
+    axis=1,
+)
+
+total_sales_potential = recipe_summary["menu_price"].sum()
+total_recipe_cost = recipe_summary["recipe_cost"].sum()
+total_margin = recipe_summary["margin"].sum()
+avg_margin_pct = recipe_summary["margin_pct"].replace({0: pd.NA}).mean()
+
+metric_cols = st.columns(4)
+metric_cols[0].metric("Potential sales", f"${total_sales_potential:,.0f}")
+metric_cols[1].metric("Theoretical food cost", f"${total_recipe_cost:,.0f}")
+metric_cols[2].metric("Margin dollars", f"${total_margin:,.0f}")
+metric_cols[3].metric(
+    "Average margin %",
+    f"{avg_margin_pct:.1f}%" if pd.notna(avg_margin_pct) else "—",
+)
+
+price_median = recipe_summary["menu_price"].median()
+margin_pct_median = recipe_summary["margin_pct"].replace({0: pd.NA}).median()
+
+
+def classify_menu_item(row: pd.Series) -> str:
+    margin_pct = row.get("margin_pct")
+    price = row.get("menu_price")
+    if pd.isna(margin_pct):
+        return "Monitor"
+    high_margin = margin_pct >= margin_pct_median if pd.notna(margin_pct_median) else margin_pct >= 50
+    high_price = price >= price_median if pd.notna(price_median) else price >= 15
+    if high_margin and high_price:
+        return "⭐ Star"
+    if high_margin and not high_price:
+        return "🐎 Plowhorse"
+    if not high_margin and high_price:
+        return "💣 Puzzle"
+    return "🛠️ Dog"
+
+
+recipe_summary["classification"] = recipe_summary.apply(classify_menu_item, axis=1)
+menu_table = recipe_summary[
+    [
+        "name",
+        "menu_price",
+        "recipe_cost",
+        "margin",
+        "margin_pct",
+        "cost_per_serving",
+        "classification",
+    ]
+].rename(
+    columns={
+        "name": "Recipe",
+        "menu_price": "Menu $",
+        "recipe_cost": "Cost $",
+        "margin": "Margin $",
+        "margin_pct": "Margin %",
+        "cost_per_serving": "Cost / serving",
+    }
+)
+
+st.subheader("Menu engineering matrix")
+st.dataframe(
+    menu_table.style.format(
+        {
+            "Menu $": "$%.2f",
+            "Cost $": "$%.2f",
+            "Margin $": "$%.2f",
+            "Margin %": "%.1f%%",
+            "Cost / serving": "$%.2f",
+        }
+    ),
+    use_container_width=True,
+    hide_index=True,
+)
+
+
+inventory_snapshot = latest_inventory()
+inventory_normalized = normalize_inventory(inventory_snapshot) if inventory_snapshot is not None else pd.DataFrame()
+
+ingredients = ingredients.copy()
+ingredients["description"] = ingredients.get("description", "").fillna("").astype(str)
+ingredients["par"] = pd.to_numeric(ingredients.get("par", 0), errors="coerce").fillna(0.0)
+ingredients["on_hand"] = pd.to_numeric(ingredients.get("on_hand", 0), errors="coerce").fillna(0.0)
+
+if not inventory_normalized.empty:
+    ingredients = ingredients.merge(
+        inventory_normalized,
+        on="description",
+        how="left",
+    )
+    ingredients["inventory_qty"] = ingredients["inventory_qty"].fillna(ingredients["on_hand"])
+    ingredients["on_hand"] = ingredients["inventory_qty"]
+
+ingredients["par_gap"] = (ingredients["par"] - ingredients["on_hand"]).clip(lower=0)
+par_shortfall = ingredients[ingredients["par_gap"] > 0].copy()
+
+st.subheader("Par shortfalls")
+if par_shortfall.empty:
+    st.success("All ingredients are at or above par levels.")
+else:
+    par_shortfall = par_shortfall.sort_values("par_gap", ascending=False)
+    st.dataframe(
+        par_shortfall[["description", "par", "on_hand", "par_gap"]]
+        .rename(
+            columns={
+                "description": "Ingredient",
+                "par": "Par",
+                "on_hand": "On hand",
+                "par_gap": "Par gap",
+            }
+        )
+        .style.format({"Par": "%.0f", "On hand": "%.0f", "Par gap": "%.0f"}),
+        use_container_width=True,
+        hide_index=True,
+    )
+
+
+orders_df = latest_order()
+st.subheader("Most recent order export")
+if orders_df is None:
+    st.info("Export an order from the Build Order page to unlock vendor insights.")
+else:
+    order = orders_df.copy()
+    order["order_qty"] = pd.to_numeric(order.get("order_qty", 0), errors="coerce").fillna(0.0)
+    order["case_cost"] = pd.to_numeric(order.get("case_cost", 0), errors="coerce").fillna(0.0)
+    if "line_total" not in order.columns:
+        order["line_total"] = order["order_qty"] * order["case_cost"]
+    order_total = order["line_total"].sum()
+    order["vendor"] = order.get("vendor", pd.Series(["Unknown"] * len(order)))
+    order["vendor"] = order["vendor"].fillna("Unknown")
+    vendor_summary = (
+        order.groupby("vendor")["line_total"].sum().reset_index().rename(
+            columns={"vendor": "Vendor", "line_total": "Spend"}
+        )
+    )
+    st.metric("Order total", f"${order_total:,.0f}")
+    st.dataframe(
+        vendor_summary.style.format({"Spend": "$%.0f"}),
+        use_container_width=True,
+        hide_index=True,
+    )

--- a/pages/6_📊_Summary.py
+++ b/pages/6_📊_Summary.py
@@ -1,12 +1,168 @@
-"""Placeholder summary dashboard."""
+"""Executive summary dashboard."""
 
 from __future__ import annotations
 
+import pandas as pd
 import streamlit as st
+
+from common.costing import compute_recipe_costs
+from common.db import latest_inventory, latest_order, read_table
 
 st.set_page_config(page_title="Summary", layout="wide")
 
 st.title("📊 Summary")
-st.info(
-    "Summary dashboards will be rebuilt on top of the CSV snapshots once ordering and inventory flows are battle-tested."
+st.caption("One-stop view of profitability, inventory health, and purchasing activity.")
+
+
+def normalize_inventory(df: pd.DataFrame) -> pd.DataFrame:
+    if df is None or df.empty:
+        return pd.DataFrame(columns=["description", "inventory_qty"])
+    inventory = df.copy()
+    columns_lower = {c.lower(): c for c in inventory.columns}
+    name_col = columns_lower.get("description")
+    if name_col is None:
+        for candidate in ["item", "ingredient", "name"]:
+            if candidate in columns_lower:
+                name_col = columns_lower[candidate]
+                break
+    qty_col = None
+    for candidate in ["on_hand", "on_hand_qty", "qty", "quantity", "count"]:
+        if candidate in columns_lower:
+            qty_col = columns_lower[candidate]
+            break
+    rename_map = {}
+    if name_col:
+        rename_map[name_col] = "description"
+    if qty_col:
+        rename_map[qty_col] = "inventory_qty"
+    inventory = inventory.rename(columns=rename_map)
+    if "description" not in inventory.columns:
+        inventory["description"] = inventory.index.astype(str)
+    if "inventory_qty" not in inventory.columns:
+        inventory["inventory_qty"] = 0
+    inventory["description"] = inventory["description"].astype(str).str.strip()
+    inventory["inventory_qty"] = pd.to_numeric(
+        inventory["inventory_qty"], errors="coerce"
+    ).fillna(0.0)
+    return inventory[["description", "inventory_qty"]]
+
+
+recipes = read_table("recipes")
+recipe_lines = read_table("recipe_lines")
+ingredients = read_table("ingredient_master")
+
+costed_lines, recipe_summary = compute_recipe_costs(recipes, recipe_lines, ingredients)
+recipe_summary = recipe_summary.fillna(0)
+recipe_count = recipe_summary.shape[0]
+
+avg_margin_pct = recipe_summary["margin_pct"].replace({0: pd.NA}).mean()
+avg_margin_pct_display = f"{avg_margin_pct*100:.1f}%" if pd.notna(avg_margin_pct) else "—"
+
+inventory_snapshot = latest_inventory()
+inventory_df = normalize_inventory(inventory_snapshot)
+
+ingredients = ingredients.copy()
+ingredients["description"] = ingredients.get("description", "").fillna("").astype(str)
+ingredients["par"] = pd.to_numeric(ingredients.get("par", 0), errors="coerce").fillna(0.0)
+ingredients["on_hand"] = pd.to_numeric(ingredients.get("on_hand", 0), errors="coerce").fillna(0.0)
+
+if not inventory_df.empty:
+    ingredients = ingredients.merge(inventory_df, on="description", how="left")
+    ingredients["on_hand"] = ingredients["inventory_qty"].fillna(ingredients["on_hand"])
+
+ingredients["par_gap"] = (ingredients["par"] - ingredients["on_hand"]).clip(lower=0)
+total_par_gap = ingredients["par_gap"].sum()
+
+orders_df = latest_order()
+order_total = 0.0
+vendor_breakdown = pd.DataFrame(columns=["Vendor", "Spend"])
+if orders_df is not None and not orders_df.empty:
+    order = orders_df.copy()
+    order["order_qty"] = pd.to_numeric(order.get("order_qty", 0), errors="coerce").fillna(0.0)
+    order["case_cost"] = pd.to_numeric(order.get("case_cost", 0), errors="coerce").fillna(0.0)
+    if "line_total" not in order.columns:
+        order["line_total"] = order["order_qty"] * order["case_cost"]
+    order_total = float(order["line_total"].sum())
+    order["vendor"] = order.get("vendor", pd.Series(["Unknown"] * len(order)))
+    order["vendor"] = order["vendor"].fillna("Unknown")
+    vendor_breakdown = (
+        order.groupby("vendor")["line_total"].sum().reset_index().rename(
+            columns={"vendor": "Vendor", "line_total": "Spend"}
+        )
+    )
+
+metric_cols = st.columns(4)
+metric_cols[0].metric("Recipes costed", f"{recipe_count}")
+metric_cols[1].metric("Average margin %", avg_margin_pct_display)
+metric_cols[2].metric("Units below par", f"{total_par_gap:,.0f}")
+metric_cols[3].metric("Latest order", f"${order_total:,.0f}")
+
+top_margin = (
+    recipe_summary.sort_values("margin", ascending=False)
+    .head(5)
+    .rename(
+        columns={
+            "name": "Recipe",
+            "menu_price": "Menu $",
+            "recipe_cost": "Cost $",
+            "margin": "Margin $",
+            "margin_pct": "Margin %",
+        }
+    )
 )
+
+par_watch = (
+    ingredients[ingredients["par_gap"] > 0]
+    .sort_values("par_gap", ascending=False)
+    .head(5)
+    .rename(
+        columns={
+            "description": "Ingredient",
+            "par": "Par",
+            "on_hand": "On hand",
+            "par_gap": "Par gap",
+        }
+    )
+)
+
+left_col, right_col = st.columns(2)
+
+with left_col:
+    st.subheader("Top margin drivers")
+    if top_margin.empty:
+        st.info("Add menu items to surface profitability insights.")
+    else:
+        st.dataframe(
+            top_margin[["Recipe", "Menu $", "Cost $", "Margin $", "Margin %"]]
+            .style.format(
+                {
+                    "Menu $": "$%.2f",
+                    "Cost $": "$%.2f",
+                    "Margin $": "$%.2f",
+                    "Margin %": "%.1f%%",
+                }
+            ),
+            use_container_width=True,
+            hide_index=True,
+        )
+
+with right_col:
+    st.subheader("Par gap watchlist")
+    if par_watch.empty:
+        st.success("No ingredients are below par.")
+    else:
+        st.dataframe(
+            par_watch.style.format({"Par": "%.0f", "On hand": "%.0f", "Par gap": "%.0f"}),
+            use_container_width=True,
+            hide_index=True,
+        )
+
+st.subheader("Vendor spend snapshot")
+if vendor_breakdown.empty:
+    st.info("Export an order to see spend by vendor.")
+else:
+    st.dataframe(
+        vendor_breakdown.style.format({"Spend": "$%.0f"}),
+        use_container_width=True,
+        hide_index=True,
+    )

--- a/pages/7_🚨_Exceptions_QA.py
+++ b/pages/7_🚨_Exceptions_QA.py
@@ -1,12 +1,129 @@
-"""Placeholder for quality alerts."""
+"""Exception & QA cockpit backed by the CSV store."""
 
 from __future__ import annotations
 
+from datetime import datetime
+
+import pandas as pd
 import streamlit as st
+
+from common.db import read_table, toast_info, toast_ok, write_table
+from common.etl import add_exception
 
 st.set_page_config(page_title="Exceptions & QA", layout="wide")
 
 st.title("🚨 Exceptions & QA")
-st.info(
-    "Exception logging will be reintroduced once the simplified data layer exposes the necessary hooks."
+st.caption("Review unresolved data issues, add follow-ups, and close out fixes.")
+
+
+def load_exceptions() -> pd.DataFrame:
+    df = read_table("exceptions")
+    if df.empty:
+        return pd.DataFrame(
+            columns=[
+                "id",
+                "timestamp",
+                "code",
+                "message",
+                "severity",
+                "context",
+                "resolved",
+                "resolved_at",
+                "resolved_by",
+            ]
+        )
+    df = df.copy()
+    for col in ["resolved", "timestamp", "severity", "context", "resolved_at", "resolved_by"]:
+        if col not in df.columns:
+            df[col] = "" if col != "resolved" else False
+    df["resolved"] = (
+        df["resolved"].astype(str).str.lower().isin(["true", "1", "yes"])
+    )
+    df["timestamp"] = df["timestamp"].fillna("")
+    df["severity"] = df["severity"].fillna("error")
+    df["context"] = df["context"].fillna("")
+    df["resolved_at"] = df.get("resolved_at", "").fillna("")
+    df["resolved_by"] = df.get("resolved_by", "").fillna("")
+    return df
+
+
+def resolve_exception(exception_id: str) -> None:
+    df = load_exceptions()
+    mask = df["id"] == exception_id
+    if not mask.any():
+        toast_info("Exception already cleared.")
+        return
+    df.loc[mask, "resolved"] = True
+    df.loc[mask, "resolved_at"] = datetime.utcnow().isoformat(timespec="seconds")
+    df.loc[mask, "resolved_by"] = st.session_state.get("resolved_by", "app_user")
+    write_table("exceptions", df)
+    toast_ok("Exception resolved")
+    st.rerun()
+
+
+exceptions_df = load_exceptions()
+open_issues = exceptions_df[~exceptions_df["resolved"]]
+resolved_issues = exceptions_df[exceptions_df["resolved"]]
+
+severity_filter = st.multiselect(
+    "Filter by severity",
+    options=["error", "warning", "info"],
+    default=["error", "warning", "info"],
 )
+
+if severity_filter:
+    open_issues = open_issues[open_issues["severity"].isin(severity_filter)]
+
+st.subheader("Log manual follow-up")
+with st.form("add_exception_form", clear_on_submit=True):
+    col1, col2 = st.columns(2)
+    severity = col1.selectbox("Severity", ["error", "warning", "info"], index=0)
+    code = col1.text_input("Code", placeholder="MISSING_PRICE")
+    message = col2.text_input("Message", placeholder="Add price to Sysco case 12345")
+    context = st.text_area("Context / remediation notes", placeholder="Link to sheet, owner, etc.")
+    submitted = st.form_submit_button("Add to log", type="primary")
+    if submitted:
+        if not code.strip():
+            toast_info("Provide a short code for the issue.")
+        else:
+            add_exception(code=code.strip(), message=message.strip(), severity=severity, context=context.strip())
+            toast_ok("Exception logged")
+            st.rerun()
+
+
+st.subheader("Open issues")
+if open_issues.empty:
+    st.success("All clear — no open exceptions.")
+else:
+    open_issues = open_issues.sort_values("timestamp", ascending=False)
+    for _, issue in open_issues.iterrows():
+        header = f"[{issue['severity'].upper()}] {issue['code']}"
+        with st.expander(header, expanded=issue["severity"] == "error"):
+            st.write(issue.get("message", ""))
+            meta_cols = st.columns(3)
+            meta_cols[0].markdown(f"**Logged:** {issue.get('timestamp', '')}")
+            meta_cols[1].markdown(f"**Context:** {issue.get('context', '') or '—'}")
+            meta_cols[2].markdown(f"**ID:** {issue.get('id', '')}")
+            if st.button("Mark resolved", key=f"resolve_{issue['id']}"):
+                resolve_exception(issue["id"])
+
+
+st.subheader("Recently resolved")
+if resolved_issues.empty:
+    st.info("Resolved issues will appear here for traceability.")
+else:
+    recent = resolved_issues.sort_values("resolved_at", ascending=False).head(20)
+    st.dataframe(
+        recent[["timestamp", "code", "message", "resolved_at", "resolved_by"]]
+        .rename(
+            columns={
+                "timestamp": "Logged",
+                "code": "Code",
+                "message": "Message",
+                "resolved_at": "Resolved",
+                "resolved_by": "By",
+            }
+        ),
+        use_container_width=True,
+        hide_index=True,
+    )


### PR DESCRIPTION
## Summary
- add ingredient cost normalization utilities and CSV exception logging to support the file-backed data layer
- implement a full recipe builder that costs ingredients from the master list and persists recipes/lines to CSV
- replace menu, summary, and QA pages with dashboards leveraging latest inventory snapshots, orders, and exception logs

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cce01214c883258d98f32c899b480d