### PR TITLE
Derive ordering vendors from data sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Mobile-first Streamlit workspace that replaces paper pads for nightly counts, ve
 - **Home dashboard** with instant metrics (active SKUs, last inventory snapshot, open order lines) and shortcuts to core flows.
 - **Inventory counts** sourced from the latest catalogs/ingredient master with touch-friendly +/- controls, draft persistence, and timestamped snapshots in `data/inventory_counts/`.
 - **Ordering workspace** with vendor filters, par/suggested math, sticky cart totals, and CSV/XLSX exports saved in `data/orders/`.
-- **Catalog uploader** powered by JSON presets for PFG, Sysco, and Produce vendors; handles missing dates, dedupes by vendor + item number, and writes to `data/catalogs/<vendor>.csv`.
+- **Catalog uploader** powered by JSON presets (ships with PFG, Sysco, Produce examples) that dedupes by vendor + item number, writes to `data/catalogs/<vendor>.csv`, and feeds the dynamic vendor pickers across the app.
 - **Ingredient master** data editor that calculates cost-per-count and stays in sync with vendor links.
 - **Export center** to download the most recent ingredient master, inventory snapshot, order export, or any vendor catalog file.
 

--- a/pages/home.py
+++ b/pages/home.py
@@ -1,11 +1,22 @@
 # Home.py
 import streamlit as st
+
+from common.db import available_vendors, load_catalogs, read_table
+
+DEFAULT_VENDORS = ["PFG", "Sysco", "Produce"]
 st.set_page_config(page_title="Dreo Kitchen Ops", layout="wide")
 st.title("Dreo Kitchen Ops")
 
 st.caption("Quick access to your daily tools. Use the sidebar anytime.")
+
+catalogs = load_catalogs()
+ingredient_master = read_table("ingredient_master")
+vendor_names = available_vendors(catalogs, ingredient_master, defaults=DEFAULT_VENDORS)
+vendor_metric = " • ".join(vendor_names) if vendor_names else "—"
+
 c1, c2, c3 = st.columns(3)
-with c1: st.metric("Vendors", "PFG • Sysco • Produce")
+with c1:
+    st.metric("Vendors", vendor_metric)
 with c2: st.metric("Active SKUs", "—")
 with c3: st.metric("Open Orders", "—")
 

--- a/replit.md
+++ b/replit.md
@@ -54,7 +54,7 @@ Preferred communication style: Simple, everyday language.
 - **Task Automation**: VS Code tasks for running, formatting, and linting
 
 ## Data Sources
-- **Vendor Catalogs**: CSV and Excel file uploads from food service distributors (PFG, Sysco, etc.)
+- **Vendor Catalogs**: CSV and Excel file uploads from food service distributors (auto-detected vendors based on what you upload)
 - **Manual Data Entry**: Recipe creation and ingredient management through web interface
 - **Configuration Files**: Environment-based settings for operational parameters
 


### PR DESCRIPTION
## Summary
- derive the ordering vendor list from catalog and ingredient data, resetting invalid selections and matching vendors exactly
- surface the shared vendor helper on the home page and expose it via common.db
- update documentation to explain the dynamic vendor discovery instead of a fixed list

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cce0133cdc83258c8d9744f612b0d7