### PR TITLE
Add shared workspaces for collaborative drafts

### DIFF
--- a/common/team_state.py
+++ b/common/team_state.py
@@ -1,0 +1,133 @@
+"""Shared workspace state helpers for collaborative pages."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+from .db import DATA
+
+# File used to persist shared workspace state across Streamlit sessions.
+TEAM_STATE_FILE = DATA / "team_state.json"
+
+# Default friendly workspace name used when no explicit workspaces exist yet.
+DEFAULT_WORKSPACE_NAME = "Main Floor"
+
+
+def _json_copy(payload: Dict[str, Any] | list[Any] | None) -> Dict[str, Any] | list[Any]:
+    """Return a deep JSON-compatible copy of the provided payload."""
+
+    if payload is None:
+        return {}
+    return json.loads(json.dumps(payload))
+
+
+def _normalize_feature(feature: str) -> str:
+    feature_key = feature.strip().lower().replace(" ", "_")
+    if not feature_key:
+        raise ValueError("Feature name must be a non-empty string")
+    return feature_key
+
+
+def _normalize_workspace(name: str) -> str:
+    cleaned = " ".join(str(name).strip().split())
+    if not cleaned:
+        raise ValueError("Workspace name must be a non-empty string")
+    return cleaned[:60]
+
+
+def _read_store() -> Dict[str, Dict[str, Any]]:
+    if not TEAM_STATE_FILE.exists():
+        return {}
+    try:
+        with TEAM_STATE_FILE.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+            if isinstance(data, dict):
+                return data
+    except json.JSONDecodeError:
+        # Corrupt/partial state files should not crash the app; start fresh.
+        pass
+    return {}
+
+
+def _write_store(store: Dict[str, Dict[str, Any]]) -> None:
+    TEAM_STATE_FILE.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = TEAM_STATE_FILE.with_suffix(".tmp")
+    with temp_path.open("w", encoding="utf-8") as handle:
+        json.dump(store, handle, indent=2, sort_keys=True)
+    temp_path.replace(TEAM_STATE_FILE)
+
+
+def list_workspaces(feature: str) -> list[str]:
+    """Return all workspace names for a feature, sorted alphabetically."""
+
+    feature_key = _normalize_feature(feature)
+    store = _read_store()
+    workspaces = store.get(feature_key, {})
+    return sorted(workspaces, key=str.casefold)
+
+
+def ensure_workspace(feature: str, name: str, *, default: Dict[str, Any] | None = None) -> str:
+    """Ensure a workspace exists and return its normalized name."""
+
+    feature_key = _normalize_feature(feature)
+    workspace_name = _normalize_workspace(name)
+    store = _read_store()
+    feature_bucket = store.setdefault(feature_key, {})
+    if workspace_name not in feature_bucket:
+        feature_bucket[workspace_name] = _json_copy(default) if default else {}
+        _write_store(store)
+    return workspace_name
+
+
+def load_workspace(feature: str, name: str, *, default: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Load a workspace payload, creating it with the default if missing."""
+
+    feature_key = _normalize_feature(feature)
+    workspace_name = _normalize_workspace(name)
+    store = _read_store()
+    payload = store.get(feature_key, {}).get(workspace_name)
+    if payload is None:
+        ensure_workspace(feature_key, workspace_name, default=default)
+        return _json_copy(default)
+    return _json_copy(payload)
+
+
+def save_workspace(feature: str, name: str, payload: Dict[str, Any]) -> None:
+    """Persist a workspace payload in the shared state file."""
+
+    feature_key = _normalize_feature(feature)
+    workspace_name = _normalize_workspace(name)
+    store = _read_store()
+    feature_bucket = store.setdefault(feature_key, {})
+    feature_bucket[workspace_name] = _json_copy(payload or {})
+    _write_store(store)
+
+
+def delete_workspace(feature: str, name: str) -> None:
+    """Remove a workspace from the store if it exists."""
+
+    feature_key = _normalize_feature(feature)
+    workspace_name = _normalize_workspace(name)
+    store = _read_store()
+    feature_bucket = store.get(feature_key)
+    if not feature_bucket or workspace_name not in feature_bucket:
+        return
+    feature_bucket.pop(workspace_name, None)
+    if feature_bucket:
+        _write_store(store)
+        return
+    # Drop the feature key entirely if no workspaces remain.
+    store.pop(feature_key, None)
+    _write_store(store)
+
+
+__all__ = [
+    "DEFAULT_WORKSPACE_NAME",
+    "delete_workspace",
+    "ensure_workspace",
+    "list_workspaces",
+    "load_workspace",
+    "save_workspace",
+]

--- a/tests/test_team_state.py
+++ b/tests/test_team_state.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from common import team_state
+
+
+def _set_store(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    store_path = tmp_path / "team_state.json"
+    monkeypatch.setattr(team_state, "TEAM_STATE_FILE", store_path)
+    return store_path
+
+
+def test_workspace_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_store(tmp_path, monkeypatch)
+
+    default_payload = {"draft": {"a": 1}, "last_submitted": {"a": 2}}
+    name = team_state.ensure_workspace("inventory", "Line Crew", default=default_payload)
+
+    loaded = team_state.load_workspace("inventory", name)
+    assert loaded == default_payload
+
+    updated_payload = {"draft": {"b": 4}, "last_submitted": {"b": 8}}
+    team_state.save_workspace("inventory", name, updated_payload)
+
+    roundtrip = team_state.load_workspace("inventory", name)
+    assert roundtrip == updated_payload
+
+
+def test_list_and_delete(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_store(tmp_path, monkeypatch)
+
+    team_state.ensure_workspace("ordering", "Beta Team")
+    team_state.ensure_workspace("ordering", " alpha  shift ")
+
+    workspaces = team_state.list_workspaces("ordering")
+    assert workspaces == ["alpha shift", "Beta Team"]
+
+    team_state.delete_workspace("ordering", "Beta Team")
+    remaining = team_state.list_workspaces("ordering")
+    assert remaining == ["alpha shift"]
+
+    team_state.delete_workspace("ordering", "alpha shift")
+    assert team_state.list_workspaces("ordering") == []


### PR DESCRIPTION
## Summary
- add a file-backed team_state helper to persist shared workspaces
- update inventory and ordering pages to sync drafts across named workspaces
- cover the new helper with unit tests to ensure workspace lifecycle behaviour

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68cce47e66c48325a02c92c4c8a04c7b