### PR TITLE
Ensure tests can import project modules

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,6 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))


### PR DESCRIPTION
## Summary
- add a pytest `conftest` that ensures the repository root is available on `sys.path`
- fix test collection so unit tests can import the `common` package reliably

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d4aa050adc8325881df6cb3199d817